### PR TITLE
Encode password admin extension

### DIFF
--- a/src/Admin/Extension/EncodePasswordExtension.php
+++ b/src/Admin/Extension/EncodePasswordExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Smart\AuthenticationBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Mathieu Ducrot <mathieu.ducrot@pia-production.fr>
+ */
+class EncodePasswordExtension extends AbstractAdminExtension
+{
+    /**
+     * @var UserPasswordEncoderInterface
+     */
+    private $encoder;
+
+    /**
+     * @param UserPasswordEncoderInterface $encoder
+     */
+    public function __construct(UserPasswordEncoderInterface $encoder)
+    {
+        $this->encoder = $encoder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preUpdate(AdminInterface $admin, $user)
+    {
+        $this->encodePassword($user);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prePersist(AdminInterface $admin, $user)
+    {
+        $this->encodePassword($user);
+    }
+
+    /**
+     * @param UserInterface $user
+     */
+    private function encodePassword(UserInterface $user)
+    {
+        if ("" === trim($user->getPlainPassword())) {
+            return;
+        }
+
+        $user->setPassword($this->encoder->encodePassword($user, $user->getPlainPassword()));
+    }
+}

--- a/src/DependencyInjection/SmartAuthenticationExtension.php
+++ b/src/DependencyInjection/SmartAuthenticationExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Smart\AuthenticationBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * @author Mathieu Ducrot <mathieu.ducrot@pia-production.fr>
+ */
+class SmartAuthenticationExtension extends Extension implements PrependExtensionInterface
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+        $loader->load('admin_extension.xml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+        $loader->load('config.yml');
+    }
+}

--- a/src/Resources/config/admin_extension.xml
+++ b/src/Resources/config/admin_extension.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="admin.extension.encode_password" class="Smart\AuthenticationBundle\Admin\Extension\EncodePasswordExtension">
+            <argument type="service" id="security.password_encoder" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,0 +1,6 @@
+
+sonata_admin:
+    extensions:
+        admin.extension.encode_password:
+            uses:
+                - Smart\AuthenticationBundle\Entity\User\UserTrait


### PR DESCRIPTION
Issue : https://github.com/smartbooster/sandbox/issues/1

## Description

This PR add the user encode password admin extension.
With the config example, it handle password encoding in admin for `preUpdate` and `prePersist` method.