### PR TITLE
Replace yokai/messenger-bundle by symfony/mailer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,9 @@ metrics:
 
 phpstan:
 	vendor/bin/phpstan analyse src --level=6 -c phpstan.neon
+
+#================================
+#           TEST
+
+phpunit:
+	vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",
-    "phpunit/phpunit": "6.*",
     "sebastian/phpcpd": "^2.0",
     "phpmetrics/phpmetrics": "^2.5",
     "phpstan/phpstan": "^0.12.3",
     "phpstan/phpstan-symfony": "^0.12.1",
     "theofidry/alice-data-fixtures": "^1.1",
-    "doctrine/doctrine-fixtures-bundle": "^3.3"
+    "doctrine/doctrine-fixtures-bundle": "^3.3",
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {
@@ -41,7 +41,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "1.1-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
   ],
   "require": {
     "smartbooster/sonata-bundle": "^1.0",
-    "yokai/messenger-bundle": "^1.3",
     "yokai/security-token-bundle": "^2.2",
-    "nelmio/alice": "^2.3 || ^3.0"
+    "nelmio/alice": "^2.3 || ^3.0",
+    "symfony/mailer": "^4.4 || ^5.1",
+    "symfony/twig-bundle": "^4.4 || ^5.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",

--- a/src/Email/ForgotPasswordEmail.php
+++ b/src/Email/ForgotPasswordEmail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Smart\AuthenticationBundle\Email;
+
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Header\Headers;
+
+class ForgotPasswordEmail extends TemplatedEmail
+{
+    /**
+     * ForgotPasswordEmail constructor.
+     * @param array<mixed> $parameters
+     * @param string $email
+     */
+    public function __construct($parameters, $email)
+    {
+        parent::__construct(new Headers(), null);
+
+        $this->from($parameters['from'])
+            ->to(new Address($email))
+            ->subject($parameters['subject'])
+            ->htmlTemplate(sprintf('email/%s/security/forgot_password.html.twig', $parameters['context']))
+            ->context($parameters)
+        ;
+    }
+}

--- a/src/Entity/User/UserTrait.php
+++ b/src/Entity/User/UserTrait.php
@@ -181,7 +181,7 @@ trait UserTrait
 
         return;
     }
-    
+
     /**
      * @inheritdoc
      */

--- a/src/Resources/views/macros/email.html.twig
+++ b/src/Resources/views/macros/email.html.twig
@@ -1,5 +1,3 @@
 {% macro renderLink(url, content, additionalStyle = '') %}
-{% spaceless %}
     <a href="{{ url }}" style="text-decoration: none;color:#428bca;{{ additionalStyle }}">{{ content }}</a>
-{% endspaceless %}
 {% endmacro %}

--- a/src/Security/SmartUserInterface.php
+++ b/src/Security/SmartUserInterface.php
@@ -33,4 +33,11 @@ interface SmartUserInterface extends UserInterface
      * @return void
      */
     public function setPlainPassword($plainPassword);
+
+    /**
+     * Ensure the user has a getEmail method
+     *
+     * @return string
+     */
+    public function getEmail();
 }

--- a/tests/Entity/User/UserTraitTest.php
+++ b/tests/Entity/User/UserTraitTest.php
@@ -16,7 +16,7 @@ class UserTraitTest extends TestCase
         $user = new User();
         $user->setLastName('Doe')
             ->setFirstName('John');
-        
+
         $this->assertEquals('John Doe', $user->getFullName());
     }
 }


### PR DESCRIPTION
## Objectif

Ensure the smartbooster/authentication-bundle works properly on a SF 4.4 stack.

## Changelog

- The yokai/messenger-bundle is abandoned and no longer maintained. The author suggests using the symfony/notifier package instead. 
But symfony/notifier is only available on SF 5.1 project. So meanwhile Sonata compatibility is finished on 5.x I suggest we use symfony/mailer
- Also fix some deprecated usage of spaceless in twig
- Fix QA phpstan `$this->container->getParameter` undefined method error (cf. https://github.com/phpstan/phpstan/issues/3200)

Note : [see this](https://github.com/mathieu-ducrot/authentication-bundle/commit/a1f31f20a1a280c31085584334a0ca96d29f7454) for notifier proposal for the future.